### PR TITLE
Support for g++7

### DIFF
--- a/src/drivers/olethros/geometry.cpp
+++ b/src/drivers/olethros/geometry.cpp
@@ -370,7 +370,7 @@ void EstimateSphere (std::vector<Vector> P, ParametricSphere* sphere)
 				}
 				delta_total += delta;
 			}
-			if (isnan(r)) {
+			if (std::isnan(r)) {
 				for (i=0; i<d; i++) {
 					center[i] =  ((*(sphere->C))[i] - mean[i]) / scale;
 				}

--- a/src/libs/musicplayer/OpenALMusicPlayer.cpp
+++ b/src/libs/musicplayer/OpenALMusicPlayer.cpp
@@ -161,7 +161,7 @@ bool OpenALMusicPlayer::streamBuffer(ALuint buffer)
 {
 	char pcm[BUFFERSIZE];
 	int size = 0;
-	const char* error = '\0';
+	const char* error = "";
 	
 	if (!stream->read(pcm, BUFFERSIZE, &size, &error)) {
 		GfError("OpenALMusicPlayer: Stream read error: %s\n", error);


### PR DESCRIPTION
Changed few primitives that are not supported in C++14 and above with backward compatible primitives supported in both newer and older version.

Error 1:

`OpenALMusicPlayer.cpp:164:22: error: invalid conversion from ‘char’ to ‘const char*’ [-fpermissive]
  const char* error = '\0';
`
Error 2:

`geometry.cpp:373:8: error: ‘isnan’ was not declared in this scope
    if (isnan(r)) {
`

Testing:
Compiled on ran the simulator on the following systems
Ubuntu 16.04.5 LTS with g++ (Ubuntu 5.4.0-6ubuntu1\~16.04.10) 5.4.0 
Ubuntu 18.04.1 LTS with g++7 g++ (Ubuntu 7.3.0-27ubuntu1\~18.04) 7.3.0